### PR TITLE
check if mfcc is empty, before mean_substraction

### DIFF
--- a/speaker_identification.py
+++ b/speaker_identification.py
@@ -183,11 +183,12 @@ class SpeakerRecognition:
         :return:
         """
         for i, speaker_mfcc in enumerate(mfcc_vector):
-            average = reduce(lambda acc, ele: acc + ele, speaker_mfcc)
-            average = list(map(lambda x: x / len(speaker_mfcc), average))
-            for j, feature_vector in enumerate(speaker_mfcc):
-                for k, feature in enumerate(feature_vector):
-                    mfcc_vector[i][j][k] -= average[k]
+            if len(speaker_mfcc) != 0:
+                average = reduce(lambda acc, ele: acc + ele, speaker_mfcc)
+                average = list(map(lambda x: x / len(speaker_mfcc), average))
+                for j, feature_vector in enumerate(speaker_mfcc):
+                    for k, feature in enumerate(feature_vector):
+                        mfcc_vector[i][j][k] -= average[k]
 
     def __init__(self, gmmpath, ubmpath, testpath, n_gauss=512, fitted=True):
         # dati degli speakers e relativi MFCC


### PR DESCRIPTION
I tried to reproduce training, and got error  , 
I found that  last element is empty list, 
I added some checking, 
 self.cepstral_mean_subtraction(self.spk_mfcc)  
![image](https://user-images.githubusercontent.com/84121856/154116475-f4aa8f61-a030-45a5-b68b-f0e531b63b76.png)
